### PR TITLE
Expandir el link a r/uruguay sobre el logo del header

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -440,3 +440,18 @@ span.flair-bronze:before {background-position: 0 -890px;}
 }
 
 /* End Addon */ 
+
+/* Link arriba del logo de uruguay en el header */
+
+#header-bottom-left .redditname a:after{
+  display: block;
+  position: absolute;
+  content: '';
+  height: 300px;
+  width: 300px;
+  top: -160px;
+  left: 50vw;
+  transform: translate(-50%,0);
+}
+
+/* End Addon */ 


### PR DESCRIPTION
Generalmente en los subreddit cuando hay un logo en el header el mismo sirve como link para ir a la página principal del subreddit. Traté de agregarlo, aunque queda medio desprolijo. Lo ideal seria poder tener el logo por separado de la imagen del header y usar su caja como link.